### PR TITLE
Send auth token in protocol, instead of message body

### DIFF
--- a/packages/cape/src/Cape.spec.ts
+++ b/packages/cape/src/Cape.spec.ts
@@ -35,6 +35,11 @@ describe('Cape', () => {
       );
     });
 
+    test('when no auth token is present, it should throw an error', async () => {
+      const cape = new Cape({ authToken: '', checkDate: new Date('2022-07-12T21:34:04.000Z') });
+      await expect(() => cape.connect({ id: 'test' })).rejects.toThrowError('Missing auth token.');
+    });
+
     test('when the server sends an error, it should throw an error', async () => {
       const id = 'GHI';
       const capeApiUrl = 'ws://localhost:82812';

--- a/packages/cape/src/methods.ts
+++ b/packages/cape/src/methods.ts
@@ -75,11 +75,7 @@ export abstract class Methods {
 
     try {
       // Set up the connection to the server
-      this.websocket = new WebsocketConnection(this.getCanonicalPath(`/v1/run/${id}`), {
-        headers: {
-          'Sec-Websocket-Protocol': `auth, ${authToken}`,
-        },
-      });
+      this.websocket = new WebsocketConnection(this.getCanonicalPath(`/v1/run/${id}`), ['cape.runtime', authToken]);
       await this.websocket.connect();
 
       // Generate the nonce for the connection.

--- a/packages/cape/src/websocket-connection.ts
+++ b/packages/cape/src/websocket-connection.ts
@@ -81,7 +81,7 @@ export class WebsocketConnection {
 
       this.socket.onopen = () => {
         debug('Websocket connection opened.');
-        debug('Websocket sub protocol selected: ', this.socket.protocol);
+        debug('Websocket sub protocol selected: ', this.socket?.protocol);
         this.isClosed = false;
         resolve();
       };

--- a/packages/cape/src/websocket-connection.ts
+++ b/packages/cape/src/websocket-connection.ts
@@ -8,6 +8,11 @@ interface Callback {
 
 export class WebsocketConnection {
   /**
+   * The WebSocket connection protocols
+   * @private
+   */
+  private readonly subprotocols: string[];
+  /**
    * The WebSocket instance.
    * @private
    */

--- a/packages/cape/src/websocket-connection.ts
+++ b/packages/cape/src/websocket-connection.ts
@@ -7,7 +7,6 @@ interface Callback {
 }
 
 export class WebsocketConnection {
-  private readonly options?: WebSocket.ClientOptions;
   /**
    * The WebSocket instance.
    * @private
@@ -33,9 +32,9 @@ export class WebsocketConnection {
    */
   isClosed = false;
 
-  constructor(url: string, options?: WebSocket.ClientOptions) {
+  constructor(url: string, subprotocols: string[]) {
     this.url = url;
-    this.options = options;
+    this.subprotocols = subprotocols;
   }
 
   /**
@@ -73,10 +72,11 @@ export class WebsocketConnection {
    */
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.socket = new WebSocket(this.url, '', this.options);
+      this.socket = new WebSocket(this.url, this.subprotocols);
 
       this.socket.onopen = () => {
-        debug('Websocket connection opened');
+        debug('Websocket connection opened.');
+        debug('Websocket sub protocol selected: ', this.socket.protocol);
         this.isClosed = false;
         resolve();
       };

--- a/packages/cape/src/websocket-connection.ts
+++ b/packages/cape/src/websocket-connection.ts
@@ -7,6 +7,7 @@ interface Callback {
 }
 
 export class WebsocketConnection {
+  private readonly options: WebSocket.ClientOptions;
   /**
    * The WebSocket instance.
    * @private
@@ -32,8 +33,9 @@ export class WebsocketConnection {
    */
   isClosed = false;
 
-  constructor(url: string) {
+  constructor(url: string, options: WebSocket.ClientOptions = {}) {
     this.url = url;
+    this.options = options;
   }
 
   /**
@@ -71,7 +73,7 @@ export class WebsocketConnection {
    */
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.socket = new WebSocket(this.url);
+      this.socket = new WebSocket(this.url, this.options);
 
       this.socket.onopen = () => {
         debug('Websocket connection opened');

--- a/packages/cape/src/websocket-connection.ts
+++ b/packages/cape/src/websocket-connection.ts
@@ -73,7 +73,7 @@ export class WebsocketConnection {
    */
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.socket = new WebSocket(this.url, this.options);
+      this.socket = new WebSocket(this.url, '', this.options);
 
       this.socket.onopen = () => {
         debug('Websocket connection opened');

--- a/packages/cape/src/websocket-connection.ts
+++ b/packages/cape/src/websocket-connection.ts
@@ -7,7 +7,7 @@ interface Callback {
 }
 
 export class WebsocketConnection {
-  private readonly options: WebSocket.ClientOptions;
+  private readonly options?: WebSocket.ClientOptions;
   /**
    * The WebSocket instance.
    * @private
@@ -33,7 +33,7 @@ export class WebsocketConnection {
    */
   isClosed = false;
 
-  constructor(url: string, options: WebSocket.ClientOptions = {}) {
+  constructor(url: string, options?: WebSocket.ClientOptions) {
     this.url = url;
     this.options = options;
   }


### PR DESCRIPTION
Goes with: https://github.com/capeprivacy/runtime/pull/126