### PR TITLE
Fix TextDecoder undefined error in browsers

### DIFF
--- a/packages/cape/src/methods.ts
+++ b/packages/cape/src/methods.ts
@@ -3,6 +3,7 @@ import {
   getAWSRootCert,
   getBytes,
   parseAttestationDocument,
+  TextDecoder,
   verifyCertChain,
   verifySignature,
   type BytesInput,
@@ -12,7 +13,6 @@ import { type Data } from 'isomorphic-ws';
 import { concat } from './bytes';
 import { encrypt } from './encrypt';
 import { WebsocketConnection } from './websocket-connection';
-import * as util from 'util';
 interface ConnectArgs {
   /**
    * The function ID to run.
@@ -113,7 +113,7 @@ export abstract class Methods {
         throw new Error(`Expected attestation document but received ${type}.`);
       }
       const doc = parseAttestationDocument(message);
-      const decoder = new util.TextDecoder();
+      const decoder = new TextDecoder();
       const decoded = decoder.decode(doc.user_data);
       const obj = JSON.parse(decoded);
       const userData = obj.func_checksum;

--- a/packages/isomorphic/src/index.browser.ts
+++ b/packages/isomorphic/src/index.browser.ts
@@ -1,5 +1,6 @@
 export * from './base64-decode-browser';
 export * from './get-bytes-browser';
 export * from './parse-attestation-document-browser';
+export * from './text-decoder-browser';
 export * from './verify-cert-chain-browser';
 export * from './verify-signature-browser';

--- a/packages/isomorphic/src/index.node.ts
+++ b/packages/isomorphic/src/index.node.ts
@@ -1,5 +1,6 @@
 export * from './base64-decode-node';
 export * from './get-bytes-node';
 export * from './parse-attestation-document-node';
+export * from './text-decoder-node';
 export * from './verify-cert-chain-node';
 export * from './verify-signature';

--- a/packages/isomorphic/src/text-decoder-browser.ts
+++ b/packages/isomorphic/src/text-decoder-browser.ts
@@ -1,0 +1,1 @@
+export const TextDecoder = globalThis.TextDecoder;

--- a/packages/isomorphic/src/text-decoder-node.ts
+++ b/packages/isomorphic/src/text-decoder-node.ts
@@ -1,0 +1,3 @@
+import { TextDecoder as _TextDecoder } from 'util';
+
+export const TextDecoder = _TextDecoder;


### PR DESCRIPTION
Added TextDecoder to the isomorphic package so it can be referenced in both environments. 