### PR TITLE
Add the ability to specify keys for encryption

### DIFF
--- a/packages/cape/src/encrypt.spec.ts
+++ b/packages/cape/src/encrypt.spec.ts
@@ -106,7 +106,7 @@ describe('encrypt', () => {
     const pubPem = forge.pki.publicKeyToPem(keypair.publicKey);
     const input = 'interesting';
 
-    const encrypted = await capeEncrypt(pubPem, input);
+    const encrypted = await capeEncrypt(input, pubPem);
     const result = encrypted.includes('cape');
     expect(result).toBe(true);
   });

--- a/packages/cape/src/encrypt.ts
+++ b/packages/cape/src/encrypt.ts
@@ -40,7 +40,7 @@ export async function encrypt(plainText: Uint8Array, publicKey: Uint8Array): Pro
  * @param plainText The plain text input to encrypt.
  */
 export async function aesEncrypt(plainText: Uint8Array, key?: string): Promise<EncryptResponse> {
-  var useKey: string;
+  let useKey: string;
   // Generate a new key if the key isn't provided.
   if (typeof key !== 'undefined') {
     // We got the key and want to just use it but need to check if

--- a/packages/cape/src/encrypt.ts
+++ b/packages/cape/src/encrypt.ts
@@ -92,10 +92,10 @@ export async function forgeRsaEncrypt(plainText: Uint8Array, key: string): Promi
  *
  * @param plainText The plain text input to encrypt.
  */
-export async function capeEncrypt(capeKey: string, plainText: string): Promise<string> {
+export async function capeEncrypt(plainText: string, RSAKey: string, AESKey?: string): Promise<string> {
   const plainTextBytes = encoder.encode(plainText);
-  const { cipherText, encapsulatedKey } = await aesEncrypt(plainTextBytes);
-  const keyCipherText = await forgeRsaEncrypt(encapsulatedKey, capeKey);
+  const { cipherText, encapsulatedKey } = await aesEncrypt(plainTextBytes, AESKey);
+  const keyCipherText = await forgeRsaEncrypt(encapsulatedKey, RSAKey);
 
   debug('CapeEncrypt keyciphertext: ', keyCipherText);
   const fullCipherText = new Uint8Array([...keyCipherText, ...cipherText]);

--- a/packages/cape/src/methods.ts
+++ b/packages/cape/src/methods.ts
@@ -58,6 +58,7 @@ export abstract class Methods {
   public abstract getEncryptKey(): Uint8Array | undefined;
 
   publicKey?: Uint8Array;
+  aesKey?: Uint8Array;
   websocket?: WebsocketConnection;
   nonce?: string;
   checkDate?: Date;
@@ -193,6 +194,7 @@ export abstract class Methods {
     try {
       if (typeof key !== 'undefined') {
         // We got the key and want to just use it and persist it.
+        // RSA keys are expected to be passed in as string.
         this.encryptKey = new TextEncoder().encode(key);
         return key;
       }
@@ -200,7 +202,7 @@ export abstract class Methods {
       // We cache the key, the assumption is that each Cape client
       // is connected to only one function, and therefore one encryption key.
       if (this.encryptKey != null) {
-        return key;
+        return new TextDecoder().decode(this.encryptKey);
       }
       const path = this.getCanonicalPath(`/v1/key`);
 
@@ -249,7 +251,7 @@ export abstract class Methods {
    */
   public async encrypt(input: string): Promise<string> {
     const key = await this.key();
-    return await capeEncrypt(key, input);
+    return await capeEncrypt(input, key);
   }
 
   /**

--- a/packages/cape/src/methods.ts
+++ b/packages/cape/src/methods.ts
@@ -58,7 +58,7 @@ export abstract class Methods {
   public abstract getEncryptKey(): Uint8Array | undefined;
 
   publicKey?: Uint8Array;
-  aesKey?: Uint8Array;
+  aesKey?: string;
   websocket?: WebsocketConnection;
   nonce?: string;
   checkDate?: Date;
@@ -218,22 +218,25 @@ export abstract class Methods {
   }
 
   /**
-   * Specifies Cape key using your authentication token or function token. This method will manage the entire lifecycle for you.
-   * The returned key is stored in the `client` object as a parameter for encrypt.
+   * The returned key is stored in the `client` object as a parameter for encrypt. This process happens in the client
+   * locally.
    *
    * @example
    * ```ts
-   * const client = new Cape({ authToken: 'my-auth-token' });
-   * await key = client.key();
+   * const client = new Cape({});
+   * await key = client.AESkey();
    * ```
    */
-  public async AESKey(key?: string): Promise<string> {
+  public async AESKey(key?: string) {
     if (typeof key !== 'undefined') {
       // We got the key and want to just use it and persist it.
-      this.encryptKey = new TextEncoder().encode(key);
-      return key;
+      this.aesKey = key;
+      return;
     }
-    return '';
+    // I don't really think we need to generate an AES key
+    // and persisted here. The behavior is that if AES isn't set
+    // explicitly, then we always generate a new AES key for encryption.
+    return;
   }
 
   /**
@@ -251,7 +254,7 @@ export abstract class Methods {
    */
   public async encrypt(input: string): Promise<string> {
     const key = await this.key();
-    return await capeEncrypt(input, key);
+    return await capeEncrypt(input, key, this.aesKey);
   }
 
   /**

--- a/packages/cape/src/methods.ts
+++ b/packages/cape/src/methods.ts
@@ -189,8 +189,19 @@ export abstract class Methods {
    * await key = client.key();
    * ```
    */
-  public async key(): Promise<string> {
+  public async key(key?: string): Promise<string> {
     try {
+      if (typeof key !== 'undefined') {
+        // We got the key and want to just use it and persist it.
+        this.encryptKey = new TextEncoder().encode(key);
+        return key;
+      }
+
+      // We cache the key, the assumption is that each Cape client
+      // is connected to only one function, and therefore one encryption key.
+      if (this.encryptKey != null) {
+        return key;
+      }
       const path = this.getCanonicalPath(`/v1/key`);
 
       const attestationUserData = await this.connect_(path);
@@ -202,6 +213,25 @@ export abstract class Methods {
     } finally {
       this.disconnect();
     }
+  }
+
+  /**
+   * Specifies Cape key using your authentication token or function token. This method will manage the entire lifecycle for you.
+   * The returned key is stored in the `client` object as a parameter for encrypt.
+   *
+   * @example
+   * ```ts
+   * const client = new Cape({ authToken: 'my-auth-token' });
+   * await key = client.key();
+   * ```
+   */
+  public async AESKey(key?: string): Promise<string> {
+    if (typeof key !== 'undefined') {
+      // We got the key and want to just use it and persist it.
+      this.encryptKey = new TextEncoder().encode(key);
+      return key;
+    }
+    return '';
   }
 
   /**

--- a/packages/cape/src/methods.ts
+++ b/packages/cape/src/methods.ts
@@ -231,12 +231,7 @@ export abstract class Methods {
     if (typeof key !== 'undefined') {
       // We got the key and want to just use it and persist it.
       this.aesKey = key;
-      return;
     }
-    // I don't really think we need to generate an AES key
-    // and persisted here. The behavior is that if AES isn't set
-    // explicitly, then we always generate a new AES key for encryption.
-    return;
   }
 
   /**


### PR DESCRIPTION
As part of the encrypt everywhere initiative, we decided to change the way the client works for local encrypt/decrypt. This is a first draft attempt at a user-facing interface. 