### PR TITLE
Reenable certificate chain validation

### DIFF
--- a/packages/cape/src/methods.ts
+++ b/packages/cape/src/methods.ts
@@ -2,6 +2,7 @@ import {
   base64Decode,
   getAWSRootCert,
   getBytes,
+  getCertificateNotBefore,
   parseAttestationDocument,
   TextDecoder,
   verifyCertChain,
@@ -66,9 +67,9 @@ export abstract class Methods {
   public abstract getFunctionChecksum(): string | undefined;
 
   publicKey?: Uint8Array;
+  checkDate?: Date;
   websocket?: WebsocketConnection;
   nonce?: string;
-  checkDate?: Date;
   rsaKeyCache: Map<string, string> = new Map<string, string>();
   dataKeyCache: Map<string, DataKey> = new Map<string, DataKey>();
 
@@ -218,7 +219,10 @@ export abstract class Methods {
         throw new Error(data.message);
       }
 
-      const doc = await this.verifyAttestationDocument(data.attestation_document, true);
+      const d = parseAttestationDocument(data.attestation_document);
+      const notBefore = getCertificateNotBefore(d.certificate);
+
+      const doc = await this.verifyAttestationDocument(data.attestation_document, notBefore);
 
       const obj = JSON.parse(new TextDecoder().decode(doc.user_data));
       const keyString = '-----BEGIN PUBLIC KEY-----\n' + addNewLines(obj.key) + '\n-----END PUBLIC KEY-----';
@@ -353,18 +357,20 @@ export abstract class Methods {
     }
   }
 
-  private async verifyAttestationDocument(message: string, skipVerifyCertChain = false): Promise<AttestationDocument> {
+  private async verifyAttestationDocument(message: string, checkDate?: Date): Promise<AttestationDocument> {
     const doc = parseAttestationDocument(message);
 
     await verifySignature(Buffer.from(message, 'base64'), doc.certificate);
 
     const rootCert = await getAWSRootCert('https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip');
 
-    if (!skipVerifyCertChain) {
-      const certResult = await verifyCertChain(doc, rootCert, this.checkDate);
-      if (!certResult.result) {
-        throw new Error(`Error validating certificate chain ${certResult.resultCode} ${certResult.resultMessage}.`);
-      }
+    if (checkDate == null) {
+      checkDate = this.checkDate;
+    }
+
+    const certResult = await verifyCertChain(doc, rootCert, checkDate);
+    if (!certResult.result) {
+      throw new Error(`Error validating certificate chain ${certResult.resultCode} ${certResult.resultMessage}.`);
     }
 
     return doc;

--- a/packages/isomorphic/src/verify-cert-chain-browser.ts
+++ b/packages/isomorphic/src/verify-cert-chain-browser.ts
@@ -54,3 +54,9 @@ IwLz3/Y=
 
   return Buffer.from(der.trim(), 'base64');
 };
+
+export const getCertificateNotBefore = (certificate: Uint8Array): Date => {
+  const cert = Certificate.fromBER(certificate);
+
+  return cert.notBefore.value;
+};

--- a/packages/isomorphic/src/verify-cert-chain-node.ts
+++ b/packages/isomorphic/src/verify-cert-chain-node.ts
@@ -49,3 +49,9 @@ export const getAWSRootCert = async (url: string): Promise<Buffer> => {
 
   return Buffer.from(der.trim(), 'base64');
 };
+
+export const getCertificateNotBefore = (certificate: Uint8Array): Date => {
+  const cert = Certificate.fromBER(certificate);
+
+  return cert.notBefore.value;
+};

--- a/packages/isomorphic/src/verify-cert-chain.spec.ts
+++ b/packages/isomorphic/src/verify-cert-chain.spec.ts
@@ -1,6 +1,6 @@
 import * as pkijs from 'pkijs';
 import { parseAttestationDocument } from './parse-attestation-document-node';
-import { getAWSRootCert, verifyCertChain } from './verify-cert-chain-node';
+import { getAWSRootCert, verifyCertChain, getCertificateNotBefore } from './verify-cert-chain-node';
 
 import * as crypto from 'crypto';
 import { readFileSync } from 'fs';
@@ -24,4 +24,14 @@ describe('verify-cert-chain.node', () => {
     const verified = await verifyCertChain(doc, root, new Date('2022-07-14T21:46:04.000Z'));
     expect(verified.result).toBe(true);
   });
+});
+
+describe('get-certificate-not-before.node', () => {
+  const file = readFileSync(join(__dirname, '../attestation.bin'));
+  const docB64 = Buffer.from(file).toString('base64');
+
+  const doc = parseAttestationDocument(docB64);
+
+  const date = getCertificateNotBefore(doc.certificate);
+  expect(date.toDateString()).toEqual('Thu Jul 14 2022');
 });


### PR DESCRIPTION
Renable certificate chain validation by setting the checkDate on the chain validation engine to the NotBefore time set on the Certificate on the attestation document. This allows certificate chain validating to happen while ignoring the short expiry windows on the certificate.